### PR TITLE
Fix build issues with Nitrogen

### DIFF
--- a/compiler/erlang_check.erl
+++ b/compiler/erlang_check.erl
@@ -474,10 +474,9 @@ process_rebar_config(Path, Terms, Config) ->
     case Config of
         no_config ->
             Includes = [ {i, absname(Path, Dir)}
-                         || Dir <- ["..",
-                                    "apps",
+                         || Dir <- ["apps",
                                     "include"] ] ++
-            [ {i, absname(Path, LibDir)} || LibDir <- LibDirs],
+            [ {i, absname(Path, filename:append(SubDir, "include"))} || SubDir <- SubDirs],
 
             Opts = ErlOpts ++ Includes,
             % If "warnings_as_errors" is left in, rebar sometimes prints the
@@ -506,8 +505,7 @@ load_makefiles([Makefile|_Rest]) ->
     Path = filename:dirname(Makefile),
     code:add_pathsa([absname(Path, "ebin")]),
     code:add_pathsa(filelib:wildcard(absname(Path, "deps") ++ "/*/ebin")),
-    {opts, [{i, absname(Path, "..")},  % Needed for weird app structures
-            {i, absname(Path, "include")},
+    {opts, [{i, absname(Path, "include")},
             {i, absname(Path, "deps")}]}.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

The following update fixes the issues with the Nitrogen build structure, and also removes some of the ".." section listed and tagged with comments such as "weird build systems". I only removed those lines under the understanding that those were remnants of the old Nitrogen support systems way back when.

Also, the main changed line "from LibDirs" to "SubDirs", was a typo, given that include_libs would deal with LibDirs and that it was missing the reference to the "include" directory contained therein.

If I'm wrong in that assumption, Just including my "SubDirs" line with a `++` should be sufficient, rather than replacing the LibDirs line.

ALSO, though I haven't played with it, this should also theoretically remove the necessity for the `is_app_root` function, since the location of Nitrogen's include directories is based on the `sub_dirs` key in rebar.config.

(Related to https://github.com/vim-erlang/vim-erlang-compiler/pull/13)
